### PR TITLE
fix(events): disallow updating picture in some cases

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -126,6 +126,7 @@ exports.addEvent = async (req, res) => {
     // Make sure the user doesn't insert malicious stuff
     const data = req.body;
     delete data.id;
+    delete data.image;
     delete data.status;
     delete data.deleted;
 
@@ -199,6 +200,7 @@ exports.editEvent = async (req, res) => {
     const event = req.event;
 
     delete data.id;
+    delete data.image;
     delete data.status;
     delete data.deleted;
 


### PR DESCRIPTION
@serge1peshcoff when uploading an image and saving the event afterwards, it would keep the id of the former image causing it not to update (at least, that's the hypothesis). This should fix this issue, will do the same for the other places where we upload images.