### PR TITLE
fix(applications): allow organizers to view an application when published. Fixes HELP-2431

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -235,7 +235,7 @@ exports.getEventPermissions = ({ permissions, event, user }) => {
 exports.getApplicationPermissions = ({ permissions, user, application }) => {
     const isMine = application.user_id === user.id;
 
-    permissions.view_application = isMine || permissions.edit_event;
+    permissions.view_application = isMine || permissions.list_applications;
     permissions.edit_application = (isMine && permissions.apply) || permissions.edit_event;
 
     return permissions;


### PR DESCRIPTION
After https://github.com/AEGEE/frontend/pull/2057 we started fetching individual applications, but the organizers only had access to it when the event itself was in draft. This is incorrect and is now updated with the event permission to list applications. So if you can see all applications, you can also view a single application.