### PR TITLE
feat(events): send SPC information email to organizers on event creation

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -188,6 +188,16 @@ exports.addEvent = async (req, res) => {
                 event
             }
         });
+
+        // Sending SPC information email to organizers.
+        await mailer.sendMail({
+            to: event.organizers.map((organizer) => organizer.notification_email),
+            subject: 'MyAEGEE: Tips on make your event a safer space',
+            template: 'events_spc_info.html',
+            parameters: {
+                event
+            }
+        });
     });
 
     return res.status(201).json({


### PR DESCRIPTION
## Summary
- Add automated SPC (Safe Person Committee) information email sent to event organizers when an event is created
- Email provides organizers with resources and information about making their events safer spaces

## Changes
- Added second email notification in event creation transaction
- Email uses the new `events_spc_info.html` template
- Subject: "MyAEGEE: Tips on make your event a safer space"
- Sent to all event organizers alongside the event creation confirmation

## Related
- Requires corresponding mailer PR with the `events_spc_info.html.eex` template